### PR TITLE
clang fix minor warnings

### DIFF
--- a/src/commands/yang_core/data_cmd_compl.c
+++ b/src/commands/yang_core/data_cmd_compl.c
@@ -46,7 +46,7 @@ enum {
 
 const char **get_list_key_values_array(struct lysc_node *y_node, int num_args, int src) {
     const char **env_vars = NULL;
-    struct lyd_node *list_data_node;
+    struct lyd_node *list_data_node = NULL;
     char xpath[1024] = {0};
 
     switch (src) {

--- a/src/commands/yang_core/data_validators.c
+++ b/src/commands/yang_core/data_validators.c
@@ -63,7 +63,7 @@ int yang_data_validator(struct cli_def *cli, const char *word, const char *value
         return CLI_OK;
     int ret = CLI_OK;
     struct lysc_node *y_node = (struct lysc_node *) cmd_model;
-    struct lysc_node_leaf *leaf;
+    struct lysc_node_leaf *leaf = NULL;
     // the value might be leaf value, list key leaf value or case node, need to be handled.
     if (y_node->nodetype == LYS_LEAF)
         leaf = (struct lysc_node_leaf *) y_node;


### PR DESCRIPTION
When clang is used instead of gcc, it raises 2 minor warnings. See the commit logs for the details.
I'll update the Makefile in order to user clang or gcc using a specific merge request.