### PR TITLE
[core]: change config directly on session using set_item delete_item

### DIFF
--- a/src/commands/default_cmd.c
+++ b/src/commands/default_cmd.c
@@ -16,7 +16,7 @@
 #include "src/onm_sysrepo.h"
 #include "yang_core/data_factory.h"
 #include "src/onm_logger.h"
-
+#include "yang_core/data_print.h"
 
 #ifdef __GNUC__
 #define UNUSED(d) d __attribute__((unused))
@@ -30,6 +30,11 @@ extern struct lyd_node *parent_data;
 unsigned int regular_count = 0;
 unsigned int debug_regular = 0;
 
+enum {
+    RUNNING_DATASTORE,
+    CANDIDATE_DATASTORE,
+    STARTUP_DATASTORE,
+};
 
 int cmd_regular_callback(struct cli_def *cli) {
     regular_count++;
@@ -47,41 +52,29 @@ int cmd_no(struct cli_def *cli, struct cli_command *c, const char *cmd, char *ar
 
 int cmd_discard_changes(struct cli_def *cli, struct cli_command *c, const char *cmd, char *argv[], int argc) {
 
-    struct data_tree *config_dtree = get_config_root_tree();
 
-    // commit changes.
-    if (config_dtree == NULL) {
-        cli_print(cli, " no config changes found!");
-        return CLI_OK;
-    }
-    free_data_tree_all();
-
-    if (sysrepo_discard_changes() != SR_ERR_OK) {
-        cli_print(cli, "failed to discard changes, sysrepo error!");
-        return CLI_ERROR;
-    }
-    cli_print(cli, "config changes discarded!");
+    if (sr_has_changes(sysrepo_get_session())) {
+        if (sysrepo_discard_changes() != SR_ERR_OK) {
+            cli_print(cli, RED" failed to discard changes, sysrepo error!" RESET);
+            return CLI_ERROR;
+        }
+        cli_print(cli, GREEN" changes discarded!"RESET);
+    } else
+        cli_print(cli, " no changes to discard!");
+    free_parent_data();
     cli_set_configmode(cli, MODE_CONFIG, NULL);
     return CLI_OK;
 }
 
 int cmd_exit2(struct cli_def *cli, struct cli_command *c, const char *cmd, char *argv[], int argc) {
 
-    struct data_tree *config_dtree = get_config_root_tree();
     if (cli->mode == MODE_CONFIG) {
-        if (config_dtree != NULL) {
-            struct data_tree *curr_root = config_dtree;
-            while (curr_root != NULL) {
-                // 1 indicate there is config diff between sysrepo and local candidate
-                if (sysrepo_has_uncommited_changes(curr_root->node) == 1) {
-                    cli_print(cli,
-                              "ERROR: there are uncommitted changes, please `commit` or `discard-changes` before exist!");
-                    return CLI_ERROR;
-                }
-                curr_root = curr_root->prev;
-            }
-            free_data_tree_all();
+        if (sr_has_changes(sysrepo_get_session())) {
+            cli_print(cli,
+                      YELLOW" there are uncommitted changes, please `commit` or `discard-changes` before exist!"RESET);
+            return CLI_ERROR;
         }
+
         sysrepo_release_ctx();
         return cli_exit(cli, c, cmd, argv, argc);
     }
@@ -99,108 +92,76 @@ int cmd_exit2(struct cli_def *cli, struct cli_command *c, const char *cmd, char 
     return cli_exit(cli, c, cmd, argv, argc);
 }
 
-int cmd_show_config_running(struct cli_def *cli, struct cli_command *c, const char *cmd, char *argv[], int argc) {
-    cli_print(cli, "not implemented, use show config-running <node>");
+int core_cmd_config_printer(struct cli_def *cli, int datastore) {
+
+    struct ly_ctx *sysrepo_ctx = (struct ly_ctx *) sysrepo_get_ctx();
+    struct lys_module *mod;
+    unsigned int index = 0;
+
+
+    while ((mod = (struct lys_module *) ly_ctx_get_module_iter(sysrepo_ctx, &index))) {
+        if (mod != NULL) {
+            if (!mod->implemented) {
+                continue;
+            }
+            if (mod->compiled->data == NULL)
+                continue;
+            char xpath[1024] = {0};
+            lysc_path(mod->compiled->data, LYSC_PATH_DATA, xpath, 1024);
+            struct lyd_node *dnode;
+            switch (datastore) {
+                case CANDIDATE_DATASTORE:
+                    dnode = get_sysrepo_candidate_node(xpath);
+                    break;
+                case RUNNING_DATASTORE:
+                    dnode = get_sysrepo_running_node(xpath);
+                    break;
+                case STARTUP_DATASTORE:
+                    dnode = get_sysrepo_startup_node(xpath);
+                    break;
+
+                default:
+                    dnode = get_sysrepo_candidate_node(xpath);
+                    break;
+            }
+
+            if (dnode == NULL)
+                continue;
+            char *result;
+            config_print_mem(&result, dnode);
+            cli_print(cli, "%s", result);
+            lyd_free_all(dnode);
+            free(result);
+        }
+    }
+    sysrepo_release_ctx();
     return CLI_OK;
+}
+
+int cmd_show_config_running(struct cli_def *cli, struct cli_command *c, const char *cmd, char *argv[], int argc) {
+    return core_cmd_config_printer(cli, RUNNING_DATASTORE);
 }
 
 int cmd_show_config_startup(struct cli_def *cli, struct cli_command *c, const char *cmd, char *argv[], int argc) {
-    cli_print(cli, "not implemented, use show config-startup <node>");
-    return CLI_OK;
+    return core_cmd_config_printer(cli, STARTUP_DATASTORE);
 }
 
-#include "yang_core/data_print.h"
 
 int cmd_show_config_candidate(struct cli_def *cli, struct cli_command *c, const char *cmd, char *argv[], int argc) {
-    enum FORMAT {
-        F_XML,
-        F_JSON,
-        F_CONFIG_LINE,
-    } format = F_CONFIG_LINE;
-    struct data_tree *config_dtree = get_config_root_tree();
-    char *format_opt = cli_get_optarg_value(cli, "format", NULL);
-    if (format_opt != NULL) {
-        to_lower(format_opt);
-        if (strcmp(format_opt, "json") == 0)
-            format = F_JSON;
-        else if (strcmp(format_opt, "xml") == 0)
-            format = F_XML;
-    }
-    // commit changes.
-    if (config_dtree == NULL) {
-        cli_print(cli, "no new config yet!");
-        return CLI_ERROR;
-    }
-    struct data_tree *curr_root = config_dtree;
-    while (curr_root != NULL) {
-        char *result;
-        if (format == F_JSON)
-            lyd_print_mem(&result, curr_root->node, LYD_JSON, 0);
-        else if (format == F_XML)
-            lyd_print_mem(&result, curr_root->node, LYD_XML, 0);
-        else
-            config_print_mem(&result, curr_root->node);
-        cli_print(cli, result, NULL);
-
-        curr_root = curr_root->prev;
-    }
-
-    return CLI_OK;
+    return core_cmd_config_printer(cli, CANDIDATE_DATASTORE);
 }
 
 int cmd_commit(struct cli_def *cli, struct cli_command *c, const char *cmd, char *argv[], int argc) {
-    sr_log_stderr(SR_LL_INF);
-    struct data_tree *config_dtree = get_config_root_tree();
-    // commit changes.
-    if (config_dtree == NULL) {
-        cli_print(cli, " no modification to commit!");
-        return CLI_OK;
-    }
-    int ret;
-    int change_added = 0;
-    struct lyd_node *all_dnodes = NULL;
-    struct data_tree *curr_root = config_dtree;
-    while (curr_root != NULL) {
-        if (sysrepo_has_uncommited_changes(curr_root->node) == 1) {
-            struct lyd_node *curr_node_cpy = NULL;
-            ret = lyd_dup_single(curr_root->node,
-                                 NULL, LYD_DUP_RECURSIVE | LYD_DUP_WITH_FLAGS, &curr_node_cpy);
-            if (ret != LY_SUCCESS) {
-                LOG_ERROR("ERROR: failed to duplicate child: %s", ly_strerrcode(ret));
-                cli_print(cli, " commit_failed: failed to commit changes!");
-                if (all_dnodes)
-                    lyd_free_all(all_dnodes);
-                sr_log_stderr(SR_LL_NONE);
-                return CLI_ERROR;
-            }
 
-            ret = lyd_insert_sibling(all_dnodes, curr_node_cpy, &all_dnodes);
-            if (ret != LY_SUCCESS) {
-                LOG_ERROR("ERROR: failed to group edited modules: %s", ly_strerrcode(ret));
-                cli_print(cli, " commit_failed: failed to commit changes!");
-                if (all_dnodes)
-                    lyd_free_all(all_dnodes);
-                sr_log_stderr(SR_LL_NONE);
-                return CLI_ERROR;
-            }
-            change_added = 1;
-        }
-        curr_root = curr_root->prev;
-    }
-    if (change_added) {
-        if (sysrepo_commit(all_dnodes) == EXIT_SUCCESS)
-            cli_print(cli, " changes applied successfully!");
-        else {
-            cli_print(cli, " commit_failed: failed to commit changes!");
-            lyd_free_all(all_dnodes);
-            sr_log_stderr(SR_LL_NONE);
-            return CLI_ERROR;
-        }
-    } else
+    if (sr_has_changes(sysrepo_get_session()) == 0) {
         cli_print(cli, " no modification to commit!");
+    } else {
+        if (sysrepo_commit() == EXIT_SUCCESS)
+            cli_print(cli, GREEN" commit: changes applied successfully!"RESET);
+        else
+            cli_print(cli, RED" commit: failed to commit changes!"RESET);
+    }
 
-    lyd_free_all(all_dnodes);
-    sr_log_stderr(SR_LL_NONE);
     return CLI_OK;
 }
 
@@ -221,9 +182,6 @@ int default_commands_init(struct cli_def *cli) {
                                                     "show", NULL, PRIVILEGE_UNPRIVILEGED,
                                                     MODE_ANY, NULL, "print the candidate/running config");
 
-//    struct cli_command *config_running = cli_register_command(cli, show, NULL,
-//                                                              "config-running", NULL, PRIVILEGE_UNPRIVILEGED,
-//                                                              MODE_ANY, NULL, "print the candidate/running config");
 
     struct cli_command *config_candidate = cli_register_command(cli, show, NULL,
                                                                 "config-candidate", cmd_show_config_candidate,

--- a/src/commands/yang_core/cmd_choice.c
+++ b/src/commands/yang_core/cmd_choice.c
@@ -60,7 +60,7 @@ int cmd_yang_case(struct cli_def *cli, struct cli_command *c, const char *cmd, c
         if (strcmp(argv[0], "delete") == 0) {
             ret = delete_data_node(y_case_n, argv[0], cli);
             if (ret != LY_SUCCESS) {
-                cli_print(cli, "Failed to delete the yang data node '%s'\n", y_case_n->name);
+                cli_print(cli, RED"Failed to delete the yang data node '%s'\n"RESET, y_case_n->name);
                 return CLI_ERROR;
             }
             return CLI_OK;
@@ -79,7 +79,7 @@ int cmd_yang_case(struct cli_def *cli, struct cli_command *c, const char *cmd, c
                 if (strcmp(optargs->name, leaf_next->name) == 0) {
                     ret = add_data_node(leaf_next, optargs->value, cli);
                     if (ret != LY_SUCCESS) {
-                        cli_print(cli, "Failed to create the yang data node for '%s'\n", y_case_n->name);
+                        cli_print(cli, RED"Failed to create the yang data node for '%s'\n"RESET, y_case_n->name);
                         return CLI_ERROR;
                     }
                     break;
@@ -117,7 +117,7 @@ int cmd_yang_no_case(struct cli_def *cli, struct cli_command *c, const char *cmd
         LY_LIST_FOR(y_case_n, leaf_next) {
             ret = delete_data_node(leaf_next, NULL, cli);
             if (ret != LY_SUCCESS) {
-                cli_print(cli, "Failed to create the yang data node for '%s'\n", y_case_n->name);
+                cli_print(cli, RED"Failed to create the yang data node for '%s'\n"RESET, y_case_n->name);
                 return CLI_ERROR;
             }
         }
@@ -126,7 +126,7 @@ int cmd_yang_no_case(struct cli_def *cli, struct cli_command *c, const char *cmd
     // data node is container.
     ret = delete_data_node(y_case_n, NULL, cli);
     if (ret != LY_SUCCESS) {
-        cli_print(cli, "Failed to delete the yang data node '%s'\n", y_case_n->name);
+        cli_print(cli, RED"Failed to delete the yang data node '%s'\n"RESET, y_case_n->name);
         return CLI_ERROR;
     }
     return CLI_OK;

--- a/src/commands/yang_core/cmd_choice.c
+++ b/src/commands/yang_core/cmd_choice.c
@@ -58,10 +58,11 @@ int cmd_yang_case(struct cli_def *cli, struct cli_command *c, const char *cmd, c
     // if the case node is leaf/leaf-list parse the value, else the case is container so command is incomplete.
     if (y_case_n->nodetype == LYS_LEAF || y_case_n->nodetype == LYS_LEAFLIST) {
         struct lysc_node *leaf_next;
-        LY_LIST_FOR(y_case_n, leaf_next) {
+        LY_LIST_FOR(y_case_n, leaf_next)
+        {
             // add data node
             char *value = cli_get_optarg_value(cli, leaf_next->name, NULL);
-            if (value){
+            if (value) {
                 ret = add_data_node(leaf_next, value, cli);
                 if (ret != LY_SUCCESS) {
                     cli_print(cli, RED
@@ -96,10 +97,13 @@ int cmd_yang_no_case(struct cli_def *cli, struct cli_command *c, const char *cmd
     // if the case node is leaf/leaf-list,we need to remove all leafs from data_node.
     if (y_case_n->nodetype == LYS_LEAF || y_case_n->nodetype == LYS_LEAFLIST) {
         struct lysc_node *leaf_next;
-        LY_LIST_FOR(y_case_n, leaf_next) {
+        LY_LIST_FOR(y_case_n, leaf_next)
+        {
             ret = delete_data_node(leaf_next, NULL, cli);
             if (ret != LY_SUCCESS) {
-                cli_print(cli, RED"Failed to create the yang data node for '%s'\n"RESET, y_case_n->name);
+                cli_print(cli, RED
+                "Failed to create the yang data node for '%s'\n"
+                RESET, y_case_n->name);
                 return CLI_ERROR;
             }
         }
@@ -108,7 +112,9 @@ int cmd_yang_no_case(struct cli_def *cli, struct cli_command *c, const char *cmd
     // data node is container.
     ret = delete_data_node(y_case_n, NULL, cli);
     if (ret != LY_SUCCESS) {
-        cli_print(cli, RED"Failed to delete the yang data node '%s'\n"RESET, y_case_n->name);
+        cli_print(cli, RED
+        "Failed to delete the yang data node '%s'\n"
+        RESET, y_case_n->name);
         return CLI_ERROR;
     }
     return CLI_OK;
@@ -155,7 +161,8 @@ int register_cmd_choice_core(struct cli_def *cli, struct lysc_node *y_node, stru
     struct lysc_node_choice *y_choice = (struct lysc_node_choice *) y_node;
     struct lysc_node *y_case;
 
-    LY_LIST_FOR((struct lysc_node *) y_choice->cases, y_case) {
+    LY_LIST_FOR((struct lysc_node *) y_choice->cases, y_case)
+    {
         sprintf(help, "configure %s (%s) [case]", y_case->name, y_case->module->name);
         sprintf(no_help, "delete %s (%s) [case]", y_case->name, y_case->module->name);
 //        struct cli_command *case_cmd = choice_cmd;
@@ -172,7 +179,15 @@ int register_cmd_choice_core(struct cli_def *cli, struct lysc_node *y_node, stru
         struct lysc_node *case_child_list = (struct lysc_node *) lysc_node_child(y_case);
         struct lysc_node *case_child;
 
-        LY_LIST_FOR(case_child_list, case_child) {
+        // for case leafs; if there are more than one leaf under the case we need to add them as opt args, if only one
+        // leaf we need to add it as require opt arg.
+        int opt_flag = CLI_CMD_ARGUMENT;
+        if (case_child_list) {
+            if (case_child_list->next != NULL)
+                opt_flag = CLI_CMD_OPTIONAL_ARGUMENT;
+        }
+        LY_LIST_FOR(case_child_list, case_child)
+        {
             // if the case-child is another choice then run recursively
             if (case_child->nodetype == LYS_CHOICE) {
                 // should be called with same mode.
@@ -188,7 +203,7 @@ int register_cmd_choice_core(struct cli_def *cli, struct lysc_node *y_node, stru
                 }
 
                 struct cli_optarg *o = cli_register_optarg(case_cmd, case_child->name,
-                                                           CLI_CMD_OPTIONAL_ARGUMENT,
+                                                           opt_flag,
                                                            PRIVILEGE_PRIVILEGED,
                                                            mode, optarg_help, optagr_get_compl_candidate_running,
                                                            yang_data_validator,

--- a/src/commands/yang_core/cmd_choice.c
+++ b/src/commands/yang_core/cmd_choice.c
@@ -40,16 +40,13 @@ int cmd_yang_no_choice(struct cli_def *cli, struct cli_command *c, const char *c
 
 int cmd_yang_case(struct cli_def *cli, struct cli_command *c, const char *cmd, char *argv[], int argc) {
 
-    struct cli_optarg_pair *optargs;
     struct lysc_node *y_node = (struct lysc_node *) c->cmd_model;
     struct lysc_node *y_case_n;
-
 
     // case might be leaf or container, for leaf we get the child, for container the child is null and we use y_node
     y_case_n = (struct lysc_node *) lysc_node_child(y_node);
     if (y_case_n == NULL)
         y_case_n = y_node;
-
 
     int ret;
     if (argc >= 1) {
@@ -57,43 +54,28 @@ int cmd_yang_case(struct cli_def *cli, struct cli_command *c, const char *cmd, c
             cli_print(cli, "  <cr>");
             return CLI_OK;
         }
-        if (strcmp(argv[0], "delete") == 0) {
-            ret = delete_data_node(y_case_n, argv[0], cli);
-            if (ret != LY_SUCCESS) {
-                cli_print(cli, RED"Failed to delete the yang data node '%s'\n"RESET, y_case_n->name);
-                return CLI_ERROR;
-            }
-            return CLI_OK;
-        }
     }
-
-
-
-    // if the case node is leaf/leaf-list parse the value, else set the next config mode.
+    // if the case node is leaf/leaf-list parse the value, else the case is container so command is incomplete.
     if (y_case_n->nodetype == LYS_LEAF || y_case_n->nodetype == LYS_LEAFLIST) {
         struct lysc_node *leaf_next;
         LY_LIST_FOR(y_case_n, leaf_next) {
             // add data node
-            optargs = cli->found_optargs;
-            while (optargs != NULL) {
-                if (strcmp(optargs->name, leaf_next->name) == 0) {
-                    ret = add_data_node(leaf_next, optargs->value, cli);
-                    if (ret != LY_SUCCESS) {
-                        cli_print(cli, RED"Failed to create the yang data node for '%s'\n"RESET, y_case_n->name);
-                        return CLI_ERROR;
-                    }
-                    break;
+            char *value = cli_get_optarg_value(cli, leaf_next->name, NULL);
+            if (value){
+                ret = add_data_node(leaf_next, value, cli);
+                if (ret != LY_SUCCESS) {
+                    cli_print(cli, RED
+                    "Failed to create the yang data node for '%s'\n"
+                    RESET, leaf_next->name);
+                    return CLI_ERROR;
                 }
-
-                optargs = optargs->next;
             }
         }
-
 
         return CLI_OK;
     }
 
-    // case is container, add data node and move to next mode
+    // case is container. command is incomplete
     cli_print(cli, "incomplete command, please use '?' for options choice");
     return CLI_ERROR;
 }
@@ -206,7 +188,7 @@ int register_cmd_choice_core(struct cli_def *cli, struct lysc_node *y_node, stru
                 }
 
                 struct cli_optarg *o = cli_register_optarg(case_cmd, case_child->name,
-                                                           CLI_CMD_ARGUMENT,
+                                                           CLI_CMD_OPTIONAL_ARGUMENT,
                                                            PRIVILEGE_PRIVILEGED,
                                                            mode, optarg_help, optagr_get_compl_candidate_running,
                                                            yang_data_validator,

--- a/src/commands/yang_core/cmd_container.c
+++ b/src/commands/yang_core/cmd_container.c
@@ -55,7 +55,7 @@ int cmd_yang_container(struct cli_def *cli, struct cli_command *c, const char *c
         ret = delete_data_node(y_node, NULL, cli);
         if (ret != LY_SUCCESS) {
             LOG_ERROR("Failed to delete the data tree");
-            cli_error(cli, "failed to execute command, error with deleting the data node.");
+            cli_error(cli, RED"failed to execute command, error with deleting the data node."RESET);
             return CLI_ERROR;
         } else
             return CLI_OK;
@@ -65,7 +65,7 @@ int cmd_yang_container(struct cli_def *cli, struct cli_command *c, const char *c
     ret = add_data_node(y_node, NULL, cli);
     if (ret != LY_SUCCESS) {
         LOG_ERROR("Failed to create the data tree");
-        cli_error(cli, "failed to execute command, error with adding the data node.");
+        cli_error(cli, RED"failed to execute command, error with adding the data node."RESET);
         return CLI_ERROR;
     }
 
@@ -92,7 +92,7 @@ int cmd_yang_no_container(struct cli_def *cli, struct cli_command *c, const char
     int ret = delete_data_node(y_node, NULL, cli);
     if (ret != LY_SUCCESS) {
         LOG_ERROR("Failed to delete the data tree");
-        cli_error(cli, "failed to execute command, error with deleting the data node.");
+        cli_error(cli, RED"failed to execute command, error with deleting the data node."RESET);
         return CLI_ERROR;
     }
     return CLI_OK;
@@ -115,7 +115,7 @@ int core_cmd_yang_show_config(struct cli_def *cli, struct cli_command *c, int da
 
     switch (datastore) {
         case CANDIDATE_DS:
-            d_node = get_local_node_data(xpath);
+            d_node = get_sysrepo_candidate_node(xpath);
             break;
         case RUNNING_DS:
             d_node = get_sysrepo_running_node(xpath);
@@ -191,7 +191,7 @@ cmd_yang_show_candidate_config_diff_container(struct cli_def *cli, struct cli_co
     char xpath[1028] = {0};
     lysc_path(y_node, LYSC_PATH_DATA, xpath, 1028);
     struct lyd_node *d_node = NULL;
-    struct lyd_node *candidate_node = get_local_node_data(xpath);
+    struct lyd_node *candidate_node = get_sysrepo_candidate_node(xpath);
     if (candidate_node == NULL) {
         cli_print(cli, " no config diff between candidate and running!");
         return CLI_OK;

--- a/src/commands/yang_core/cmd_leaf.c
+++ b/src/commands/yang_core/cmd_leaf.c
@@ -32,7 +32,7 @@ int cmd_yang_leaf_list(struct cli_def *cli, struct cli_command *c, const char *c
         if (yang_data_validator(cli, cmd, argv[i], c->cmd_model) != CLI_OK) return CLI_ERROR_ARG;
         ret = add_data_node(y_node, argv[i], cli);
         if (ret != LY_SUCCESS) {
-            cli_print(cli, "Failed to create the yang data node for '%s'\n", y_node->name);
+            cli_print(cli, RED"Failed to create the yang data node for '%s'\n"RESET, y_node->name);
             return CLI_ERROR;
         }
     }
@@ -54,7 +54,7 @@ int cmd_yang_no_leaf_list(struct cli_def *cli, struct cli_command *c, const char
 
     ret = delete_data_node(y_node, argv[0], cli);
     if (ret != LY_SUCCESS) {
-        cli_print(cli, "Failed to delete the yang data node for '%s'\n", y_node->name);
+        cli_print(cli, RED"Failed to delete the yang data node for '%s'\n"RESET, y_node->name);
         return CLI_ERROR;
     }
     return CLI_OK;
@@ -68,7 +68,7 @@ int cmd_yang_leaf(struct cli_def *cli, struct cli_command *c, const char *cmd, c
     char *value = cli_get_optarg_value(cli, "value", NULL);
     ret = add_data_node(y_node, value, cli);
     if (ret != LY_SUCCESS) {
-        cli_print(cli, "Failed to create the yang data node for '%s'\n", y_node->name);
+        cli_print(cli, RED"Failed to create the yang data node for '%s'\n"RESET, y_node->name);
         return CLI_ERROR;
     }
     return CLI_OK;
@@ -83,14 +83,11 @@ int cmd_yang_no_leaf(struct cli_def *cli, struct cli_command *c, const char *cmd
         if (!strcmp(argv[0], "?")) {
             cli_print(cli, " <cr>");
             return CLI_OK;
-        } else{
-            cli_print(cli, " ERROR: invalid input %s",argv[0]);
-            return CLI_ERROR;
         }
     }
     ret = delete_data_node(y_node, NULL, cli);
     if (ret != LY_SUCCESS) {
-        cli_print(cli, "Failed to delete the yang data node for '%s'\n", y_node->name);
+        cli_print(cli, RED"Failed to delete the yang data node for '%s'\n"RESET, y_node->name);
         return CLI_ERROR;
     }
     return CLI_OK;

--- a/src/commands/yang_core/cmd_list.c
+++ b/src/commands/yang_core/cmd_list.c
@@ -24,7 +24,16 @@ int cmd_print_list_order(struct cli_def *cli, struct cli_command *c, const char 
     int curr_indx = 10;
     struct lyd_node *next = NULL, *entry_child = NULL;
     struct lysc_node *y_node = (struct lysc_node *) c->cmd_model;
-    struct lyd_node *list_entries = get_local_list_nodes(y_node);
+
+    struct lyd_node *list_entries;
+    char xpath[1024] = {0};
+    if (y_node->parent != NULL && y_node->parent->parent != NULL) {
+        lysc_path(y_node->parent->parent, LYSC_PATH_DATA, xpath, 1028);
+        list_entries = lyd_child(get_sysrepo_candidate_node(xpath));
+    } else {
+        return EXIT_FAILURE;
+    }
+
     char line[265] = {'\0'};
     LY_LIST_FOR(list_entries, next)
     {
@@ -70,7 +79,7 @@ int cmd_yang_list(struct cli_def *cli, struct cli_command *c, const char *cmd, c
 
         // Check for conversion errors
         if ((*idx_endptr != '\0' && *idx_endptr != '\n') || (index == 0)) {
-            cli_error(cli, "ERROR: <index> must be numeric greater than 0, entered value=%s", optargs->value);
+            cli_error(cli, RED"ERROR: <index> must be numeric greater than 0, entered value=%s"RESET, optargs->value);
             return CLI_ERROR;
         }
     }
@@ -134,7 +143,7 @@ int cmd_yang_no_list(struct cli_def *cli, struct cli_command *c, const char *cmd
     ret = delete_data_node_list(y_node, cli);
     if (ret != LY_SUCCESS) {
         LOG_ERROR("Failed to delete the data tree");
-        cli_print(cli, "failed to execute command, error with adding the data node.");
+        cli_print(cli, RED"failed to execute command, error with adding the data node."RESET);
         return CLI_ERROR;
     }
     return CLI_OK;
@@ -162,7 +171,7 @@ int core_yand_show_config(struct cli_def *cli, struct cli_command *c, int datast
             cli_print(cli, "config diff is support for config-candidate only.");
             return CLI_ERROR;
         }
-        struct lyd_node *candidate_node = get_local_node_data(xpath);
+        struct lyd_node *candidate_node = get_sysrepo_candidate_node(xpath);
         if (candidate_node == NULL) {
             cli_print(cli, " no config diff between candidate and running for node '%s'", xpath);
             return CLI_OK;
@@ -182,7 +191,7 @@ int core_yand_show_config(struct cli_def *cli, struct cli_command *c, int datast
     } else {
         switch (datastore) {
             case CANDIDATE_DS:
-                d_node = get_local_node_data(xpath);
+                d_node = get_sysrepo_candidate_node(xpath);
                 break;
             case RUNNING_DS:
                 d_node = get_sysrepo_running_node(xpath);

--- a/src/commands/yang_core/cmd_list.c
+++ b/src/commands/yang_core/cmd_list.c
@@ -104,7 +104,7 @@ int cmd_yang_list(struct cli_def *cli, struct cli_command *c, const char *cmd, c
 
     if (ret != LY_SUCCESS) {
         LOG_ERROR("Failed to create/delete the data tree");
-        cli_print(cli, "failed to execute command, error with adding the data node. list");
+        cli_print(cli, RED"failed to execute command, error with adding the data node. list"RESET);
         return CLI_ERROR;
     }
     if (!has_none_key_node) {

--- a/src/commands/yang_core/data_cmd_compl.c
+++ b/src/commands/yang_core/data_cmd_compl.c
@@ -18,6 +18,14 @@
 #include "data_cmd_compl.h"
 
 
+enum {
+    CANDIDATE_SRC,
+    RUNNING_SRC,
+    STARTUP_SRC,
+    CANDIDATE_OR_RUNNING_SRC,
+    OPERATION_SRC
+};
+
 void identityref_add_comphelp(struct lysc_ident *identity, const char *word, struct cli_comphelp *comphelp) {
     if (!identity) {
         return;
@@ -66,44 +74,67 @@ int options_contain(const char **options, const char *str, int size) {
     return 0;
 }
 
-enum {
-    CANDIDATE_SRC,
-    RUNNING_SRC,
-    STARTUP_SRC,
-    CANDIDATE_OR_RUNNING_SRC,
-    OPERATION_SRC
-};
+extern struct cli_def *cli;
 
 const char **get_list_key_values_array(struct lysc_node *y_node, int num_args, int ds) {
     const char **env_vars = NULL;
     struct lyd_node *list_data_node = NULL;
+    struct lyd_node *curr_parent = get_current_parent_dnode();
     char xpath[1024] = {0};
+    // keep in mind the the y_node here is the key leaf node.
+    // we need to get the xpath for the node before fetching from sysrepo,
+    // based on the y_node and the current parent_node (config level) we choose if the xpath
+    // taken from the current_parent lyd_node, or from the y_node.
 
+    // first set the xpath to y_node parent, if th
+    struct lysc_node *y_nod_list_parent = get_parent_y_node_list(y_node->parent);
+    lysc_path(y_nod_list_parent, LYSC_PATH_DATA, xpath, 1024);
+
+    // then check if y_node is child of current_parent, to use the current_parent data_path in the xpath.
+    if (curr_parent && y_node->parent != NULL && y_node->parent->parent != NULL) {
+        char curr_parent_xpath[1024] = {0};
+        lysc_path(curr_parent->schema, LYSC_PATH_DATA, curr_parent_xpath, 1024);
+        // if the y_node parent config level (list of root container) xpath is the same as current_parent,
+        // then we use the current_parent xpath, if not we use the y_node
+        // ( the different y_node and current_parent node xpath is the case of leafref compl
+        // the where current config mode is different from the leafref)
+
+        if (!strcmp(curr_parent_xpath, xpath)) {
+            lyd_path(curr_parent, LYD_PATH_STD, xpath, 1024);
+            // if parent_node is different from the y_node parent_parent (which supposed to be the parent of the list)
+            // then add the relative path, example of difference in ietf-access-control-list.yang's list ace:
+            // acls-ietf
+            //   acl my_acl
+            //      aces ace my_ace1 <--
+            //         matches l3 ipv4 destination-ipv4-network 2.2.2.0/24
+            //         actions forwarding ietf-access-control-list:accept
+            //         actions logging ietf-access-control-list:log-none
+            //
+            if (strcmp(curr_parent->schema->name, y_node->parent->parent->name) != 0) {
+                strlcat(xpath, "/", sizeof(xpath));
+                strlcat(xpath, get_relative_path(y_node->parent->parent), sizeof(xpath));
+            }
+
+        }
+
+    }
     switch (ds) {
         case CANDIDATE_SRC:
-            list_data_node = get_local_list_nodes(y_node->parent);
-            break;
         case CANDIDATE_OR_RUNNING_SRC:
-            list_data_node = get_local_list_nodes(y_node->parent);
-            if (list_data_node) // if list_data found in candidate break, else try the running ds.
-                break;
+            list_data_node = lyd_child(get_sysrepo_candidate_node(xpath));
+
+            break;
         case RUNNING_SRC:
-            if (y_node->parent != NULL && y_node->parent->parent != NULL) {
-                lysc_path(y_node->parent->parent, LYSC_PATH_DATA, xpath, 1028);
-                list_data_node = lyd_child(get_sysrepo_running_node(xpath));
-            }
+            list_data_node = lyd_child(get_sysrepo_running_node(xpath));
+
             break;
         case STARTUP_SRC:
-            if (y_node->parent != NULL && y_node->parent->parent != NULL) {
-                lysc_path(y_node->parent->parent, LYSC_PATH_DATA, xpath, 1028);
-                list_data_node = lyd_child(get_sysrepo_startup_node(xpath));
-            }
+            list_data_node = lyd_child(get_sysrepo_startup_node(xpath));
+
             break;
         case OPERATION_SRC:
-            if (y_node->parent != NULL && y_node->parent->parent != NULL) {
-                lysc_path(y_node->parent->parent, LYSC_PATH_DATA, xpath, 1028);
-                list_data_node = lyd_child(get_sysrepo_operational_node(xpath));
-            }
+            list_data_node = lyd_child(get_sysrepo_operational_node(xpath));
+
             break;
     }
     struct lyd_node *next = NULL;

--- a/src/commands/yang_core/data_factory.c
+++ b/src/commands/yang_core/data_factory.c
@@ -139,17 +139,21 @@ int edit_node_data_tree_list(struct lysc_node *y_node, int edit_type,
             curr_indx += 10;
         }
     }
-
-
     if (edit_type == EDIT_DATA_ADD) {
 
-        if (!item_found)
+        if (!item_found) {
             ret = sr_set_item(sysrepo_get_session(), all_xpath, NULL, 0);
+            if (ret != SR_ERR_OK)
+                goto done;
+        }
         if (is_update_parent)
             parent_data = new_parent;
     } else {
-        if (item_found)
+        if (item_found) {
             ret = sr_delete_item(sysrepo_get_session(), all_xpath, 0);
+            if (ret != SR_ERR_OK)
+                goto done;
+        }
         else
             cli_print(cli, " item not found in datastore!");
         lyd_free_tree(new_parent);
@@ -162,7 +166,7 @@ int edit_node_data_tree_list(struct lysc_node *y_node, int edit_type,
     }
     free(predicate_str);
     sysrepo_release_ctx();
-    return EXIT_SUCCESS;
+    return ret;
 }
 
 
@@ -217,7 +221,13 @@ static int edit_node_data_tree(struct lysc_node *y_node, char *value, int edit_t
             else {
                 lyd_free_tree(new_parent);
                 if (item_found) {
-                    ret = sr_delete_item(sysrepo_get_session(), xpath, 0);
+                    char all_xpath[1024] = {0};
+                    lyd_path(parent_data, LYD_PATH_STD, all_xpath, 1024);
+                    strlcat(all_xpath, "/", sizeof(all_xpath));
+                    strlcat(all_xpath, xpath, sizeof(all_xpath));
+                    ret = sr_delete_item(sysrepo_get_session(), all_xpath, 0);
+                    if (ret != SR_ERR_OK)
+                        break;
                 } else
                     cli_print(cli, " item not found in datastore!");
                 break;
@@ -249,13 +259,13 @@ static int edit_node_data_tree(struct lysc_node *y_node, char *value, int edit_t
 
             if (edit_type == EDIT_DATA_ADD) {
                 if (!item_found || strcmp(lyd_get_value(new_leaf), value) != 0) {
-                    // we can't change the value by setting the item again, so we delete then add.
-                    sr_delete_item(sysrepo_get_session(), all_xpath, 0);
-                    ret = sr_set_item_str(sysrepo_get_session(), all_xpath, value, NULL, 0);
+                    // SR_EDIT_ISOLATE is needed to change the edit value of leaf,
+                    // for example we set the value of mtu to 1300, then we change it to 1200 without commit,
+                    // for this case SR_EDIT_ISOLATE is required.
+                    ret = sr_set_item_str(sysrepo_get_session(), all_xpath, value, NULL, SR_EDIT_ISOLATE);
                     if (ret != SR_ERR_OK)
                         break;
                 }
-                lyd_change_term(new_leaf, value);
 
             } else {
                 lyd_free_tree(new_leaf);

--- a/src/commands/yang_core/data_factory.c
+++ b/src/commands/yang_core/data_factory.c
@@ -17,12 +17,15 @@
 #include "src/onm_logger.h"
 
 
-struct lyd_node *parent_data;
-struct data_tree *curr_root;
-extern struct data_tree *config_root_tree;
+struct lyd_node *parent_data = NULL;
 
-struct data_tree *get_config_root_tree() {
-    return config_root_tree;
+void free_parent_data() {
+    lyd_free_tree(parent_data);
+    parent_data = NULL;
+}
+
+struct lyd_node *get_current_parent_dnode() {
+    return parent_data;
 }
 
 // edit type
@@ -32,48 +35,22 @@ enum {
 };
 
 
-// get list data node for y_node from local data_tree.
-struct lyd_node *get_local_list_nodes(struct lysc_node *y_node) {
-    char xpath[256] = {0};
-    struct lyd_node *match = NULL;
-    if (parent_data != NULL) {
-        if (parent_data->schema == y_node->parent)
-            match = parent_data;
-        else {
-            sprintf(xpath, "%s", get_relative_path(y_node->parent));
-            lyd_find_path(parent_data, xpath, 0, &match);
-            // for leafref if node does not exist in parent_data, check all roots.
+struct lyd_node *get_sysrepo_candidate_node(char *xpath) {
+    sr_data_t *sysrepo_subtree;
+    int ret = sr_get_subtree(sysrepo_get_session(), xpath, 0, &sysrepo_subtree);
+    if (ret == SR_ERR_OK && sysrepo_subtree != NULL)
+        return sysrepo_subtree->tree;
 
-        }
-    }
-    if (match == NULL) {
-        struct data_tree *curr_node = config_root_tree;
-        lysc_path(y_node->parent, LYSC_PATH_DATA, xpath, 256);
-        while (curr_node != NULL && curr_node->node != NULL) {
-            lyd_find_path(curr_node->node, xpath, 0, &match);
-            if (match != NULL)
-                break;
-            curr_node = curr_node->prev;  // Move to the next node
-        }
-    }
-
-    if (match == NULL)
+    if (ret == SR_ERR_NOT_FOUND)
         return NULL;
-    struct lyd_node *list_node = lyd_child(match);
-    struct lyd_node *next = NULL;
-    LY_LIST_FOR(list_node, next)
-    {
-        if (next->schema->nodetype == LYS_LIST) {
-            if (!strcmp(y_node->name, next->schema->name))
-                return next;
-        }
-    }
+    LOG_ERROR("data_factory.c: error returning sysrepo data, code=%d", ret);
     return NULL;
 }
 
+
 struct lyd_node *get_sysrepo_running_node(char *xpath) {
     sr_data_t *sysrepo_subtree;
-    int ret = sr_get_subtree(sysrepo_get_session(), xpath, 0, &sysrepo_subtree);
+    int ret = sr_get_subtree(sysrepo_get_running_session(), xpath, 0, &sysrepo_subtree);
     if (ret == SR_ERR_OK && sysrepo_subtree != NULL)
         return sysrepo_subtree->tree;
     if (ret == SR_ERR_NOT_FOUND)
@@ -104,22 +81,10 @@ struct lyd_node *get_sysrepo_startup_node(char *xpath) {
     return NULL;
 }
 
-struct lyd_node *get_local_node_data(char *xpath) {
-    struct lyd_node *match = NULL;
-    struct data_tree *curr_node = config_root_tree;
-    while (curr_node != NULL && curr_node->node != NULL) {
-        lyd_find_path(curr_node->node, xpath, 0, &match);
-        if (match != NULL)
-            break;
-        curr_node = curr_node->prev;  // Move to the next node
-    }
-    return match;
-}
-
 
 int edit_node_data_tree_list(struct lysc_node *y_node, int edit_type,
                              int index, struct cli_def *cli, int is_update_parent) {
-    int ret;
+    int ret = EXIT_SUCCESS;
     char xpath[265];
     char *predicate_str;
     memset(xpath, 0, 265);
@@ -131,10 +96,9 @@ int edit_node_data_tree_list(struct lysc_node *y_node, int edit_type,
     }
 
     sprintf(xpath, "%s", get_relative_path(y_node));
-    struct lyd_node *curr_parent, *new_parent;
+    struct lyd_node *curr_parent, *new_parent = NULL;
     // set current parent and xpath based on the list location in the tree.
     if (parent_data == NULL) {
-        curr_parent = curr_root->node;
         lysc_path(y_node, LYSC_PATH_DATA, xpath, 256);
     } else
         curr_parent = parent_data;
@@ -142,15 +106,19 @@ int edit_node_data_tree_list(struct lysc_node *y_node, int edit_type,
     predicate_str = create_list_predicate_from_optargs(cli, y_node);
     strcat(xpath, predicate_str);
 
-    ret = lyd_find_path(curr_parent, xpath, 0, &new_parent);
-    if (new_parent == NULL || ret == LY_EINCOMPLETE)
-        ret = lyd_new_path2(curr_parent, sysrepo_ctx, xpath, NULL, 0,
-                            0, LYD_NEW_PATH_UPDATE, NULL, &new_parent);
+    char all_xpath[1024] = {0};
+    lyd_path(parent_data, LYD_PATH_STD, all_xpath, 1024);
+    strlcat(all_xpath, "/", sizeof(all_xpath));
+    strlcat(all_xpath, xpath, sizeof(all_xpath));
 
-    if (ret != LY_SUCCESS) {
-        print_ly_err(ly_err_first(sysrepo_ctx), "data_factory.c", cli);
-        goto done;
+    int item_found = 1;
+    new_parent = get_sysrepo_candidate_node(all_xpath);
+    if (new_parent == NULL) {
+        item_found = 0;
+        ret = lyd_new_path2(curr_parent, sysrepo_ctx, all_xpath, NULL, 0,
+                            0, LYD_NEW_PATH_UPDATE, NULL, &new_parent);
     }
+
     if (index) {
         // index start from 10 and the step is 10, 10,20,30...
         int curr_indx = 10;
@@ -171,17 +139,30 @@ int edit_node_data_tree_list(struct lysc_node *y_node, int edit_type,
             curr_indx += 10;
         }
     }
+
+
     if (edit_type == EDIT_DATA_ADD) {
+
+        if (!item_found)
+            ret = sr_set_item(sysrepo_get_session(), all_xpath, NULL, 0);
         if (is_update_parent)
             parent_data = new_parent;
-    } else
+    } else {
+        if (item_found)
+            ret = sr_delete_item(sysrepo_get_session(), all_xpath, 0);
+        else
+            cli_print(cli, " item not found in datastore!");
         lyd_free_tree(new_parent);
+    }
 
 
     done:
+    if (ret != LY_SUCCESS) {
+        print_ly_err(ly_err_first(sysrepo_ctx), "data_factory.c", cli);
+    }
     free(predicate_str);
     sysrepo_release_ctx();
-    return ret;
+    return EXIT_SUCCESS;
 }
 
 
@@ -197,7 +178,7 @@ int delete_data_node_list(struct lysc_node *y_node, struct cli_def *cli) {
 
 
 static int edit_node_data_tree(struct lysc_node *y_node, char *value, int edit_type, struct cli_def *cli) {
-    int ret;
+    int ret = LY_SUCCESS;
     char xpath[256];
     memset(xpath, '\0', 256);
     struct ly_ctx *sysrepo_ctx = (struct ly_ctx *) sysrepo_get_ctx();
@@ -217,52 +198,14 @@ static int edit_node_data_tree(struct lysc_node *y_node, char *value, int edit_t
                 snprintf(xpath, 256, "%s", get_relative_path(y_node));
             else
                 lysc_path(y_node, LYSC_PATH_DATA, xpath, 256);
-            // set the config_data_tree
-            // check if this is first node in the schema, to set the root node.
-            if (y_node->parent == NULL) {
-                // check if config_tree is empty
-                if (config_root_tree == NULL) {
-                    config_root_tree = malloc(sizeof(struct data_tree));
-                    config_root_tree->node = get_sysrepo_running_node(xpath);
-                    config_root_tree->prev = NULL;
-                    curr_root = config_root_tree;
-                    if (config_root_tree->node != NULL) {
-                        parent_data = config_root_tree->node;
-                        sysrepo_release_ctx();
-                        return EXIT_SUCCESS;
-                    }
-
-                } else {
-                    // check if data for this schema already exist in the tree. and use that tree if not allocat a new one
-                    // and link it to config_data_tree
-                    curr_root = config_root_tree;
-                    while (curr_root != NULL) {
-                        if (strcmp(curr_root->node->schema->name, y_node->name) == 0 &&
-                            strcmp(curr_root->node->schema->module->name, y_node->module->name) == 0 &&
-                            y_node->parent == NULL) {
-                            // root data tree found, we just set parent_data to the found root and exit without creating
-                            // new path.
-                            parent_data = curr_root->node;
-                            sysrepo_release_ctx();
-                            return LY_SUCCESS;
-                        }
-                        curr_root = curr_root->prev;
-                    }
-                    // create new root_tree node and link it to the list.
-                    struct data_tree *new_root = malloc(sizeof(struct data_tree));
-                    new_root->node = get_sysrepo_running_node(xpath);
-                    new_root->prev = config_root_tree;
-                    config_root_tree = new_root;
-                    curr_root = config_root_tree;
-                    parent_data = curr_root->node;
-                }
-            }
 
             struct lyd_node *new_parent = NULL;
 
-
+            int item_found = 1;
             // check if the node exist in the tree, if not create new node in the tree.
             ret = lyd_find_path(parent_data, xpath, 0, &new_parent);
+            if (ret == LY_ENOTFOUND)
+                item_found = 0;
             if (new_parent == NULL || ret == LY_EINCOMPLETE) {
                 ret = lyd_new_path(parent_data, sysrepo_ctx, xpath, NULL, LYD_NEW_PATH_UPDATE, &new_parent);
             }
@@ -273,10 +216,12 @@ static int edit_node_data_tree(struct lysc_node *y_node, char *value, int edit_t
                 parent_data = new_parent;
             else {
                 lyd_free_tree(new_parent);
+                if (item_found) {
+                    ret = sr_delete_item(sysrepo_get_session(), xpath, 0);
+                } else
+                    cli_print(cli, " item not found in datastore!");
                 break;
             }
-
-            curr_root->node = curr_root->node ? curr_root->node : parent_data;
         }
             break;
 
@@ -287,20 +232,40 @@ static int edit_node_data_tree(struct lysc_node *y_node, char *value, int edit_t
             else
                 snprintf(xpath, 256, "%s", get_relative_path(y_node));
 
-            struct lyd_node *new_leaf;
+            struct lyd_node *new_leaf = NULL;
+            int item_found = 1;
+            char all_xpath[1024] = {0};
+            lyd_path(parent_data, LYD_PATH_STD, all_xpath, 1024);
+            strlcat(all_xpath, "/", sizeof(all_xpath));
+            strlcat(all_xpath, xpath, sizeof(all_xpath));
 
-            // check if node already exist in data_tree, if not creat a new node.
-            ret = lyd_find_path(parent_data, xpath, 0, &new_leaf);
-            if (new_leaf == NULL || ret == LY_EINCOMPLETE) {
-                ret = lyd_new_path(parent_data, sysrepo_ctx, xpath, value, LYD_NEW_PATH_UPDATE,
-                                   &new_leaf);
+            new_leaf = get_sysrepo_candidate_node(all_xpath);
+            if (new_leaf == NULL) {
+                item_found = 0;
+                ret = lyd_new_path2(parent_data, sysrepo_ctx, xpath, value, strlen(value), LYD_ANYDATA_STRING,
+                                    LYD_NEW_PATH_OUTPUT, NULL, &new_leaf);
             }
 
 
-            if (edit_type == EDIT_DATA_ADD)
+            if (edit_type == EDIT_DATA_ADD) {
+                if (!item_found || strcmp(lyd_get_value(new_leaf), value) != 0) {
+                    // we can't change the value by setting the item again, so we delete then add.
+                    sr_delete_item(sysrepo_get_session(), all_xpath, 0);
+                    ret = sr_set_item_str(sysrepo_get_session(), all_xpath, value, NULL, 0);
+                    if (ret != SR_ERR_OK)
+                        break;
+                }
                 lyd_change_term(new_leaf, value);
-            else
+
+            } else {
                 lyd_free_tree(new_leaf);
+                if (item_found) {
+                    ret = sr_delete_item(sysrepo_get_session(), all_xpath, 0);
+                    if (ret != SR_ERR_OK)
+                        break;
+                } else
+                    cli_print(cli, " item not found in datastore!");
+            }
             break;
 
     }

--- a/src/commands/yang_core/data_factory.h
+++ b/src/commands/yang_core/data_factory.h
@@ -3,6 +3,7 @@
 #ifndef ONMCLI_DATA_FACTORY_H
 #define ONMCLI_DATA_FACTORY_H
 
+#include <bsd/string.h>
 #include <libyang/libyang.h>
 #include <libyang/parser_data.h>
 #include <libyang/tree_data.h>
@@ -11,12 +12,7 @@
 #include <libyang/log.h>
 #include "lib/libcli/libcli.h"
 
-
-struct data_tree *get_config_root_tree();
-
-void free_data_tree_all();
-
-void free_data_tree(struct data_tree *dtree);
+struct lyd_node *get_sysrepo_candidate_node(char *xpath);
 
 struct lyd_node *get_sysrepo_running_node(char *xpath);
 
@@ -30,14 +26,17 @@ struct lyd_node *get_local_list_nodes(struct lysc_node *y_node);
 
 struct lyd_node *get_local_or_sr_list_nodes(struct lysc_node *y_node);
 
+struct lyd_node *get_current_parent_dnode();
+
 int add_data_node(struct lysc_node *y_node, char *value, struct cli_def *cli);
 
-int add_data_node_list(struct lysc_node *y_node,  int index, struct cli_def *cli,
+int add_data_node_list(struct lysc_node *y_node, int index, struct cli_def *cli,
                        int has_none_key_nodes);
 
 int delete_data_node(struct lysc_node *y_node, char *value, struct cli_def *cli);
 
 int delete_data_node_list(struct lysc_node *y_node, struct cli_def *cli);
 
+void free_parent_data();
 
 #endif //ONMCLI_DATA_FACTORY_H

--- a/src/commands/yang_core/data_print.c
+++ b/src/commands/yang_core/data_print.c
@@ -18,7 +18,6 @@ void print_indentation(int pos, char **result) {
 
 void print_root_container_dnode(struct lyd_node *dnode, int pos, char **result) {
     char line[1024] = {0};
-
     strlcat(line, get_root_ynode_cmd_name((struct lysc_node*)dnode->schema), sizeof(line));
     strlcat(line, "\n", sizeof(line));
 
@@ -86,11 +85,15 @@ void print_list_dnode(struct lyd_node *dnode, int pos, char **result) {
                 if (strcmp(key_dflt_val,lyd_get_value(next)) != 0) {
                     strlcat(line, next->schema->name, sizeof(line));
                     strlcat(line, " ", sizeof(line));
+                    strlcat(line, BLUE, sizeof(line)); // Start color
                     strlcat(line, lyd_get_value(next), sizeof(line));
+                    strlcat(line, RESET, sizeof(line)); // Reset color
                     strlcat(line, " ", sizeof(line));
                 }
             } else {
+                strlcat(line, BLUE, sizeof(line)); // Start color
                 strlcat(line, lyd_get_value(next), sizeof(line));
+                strlcat(line, RESET, sizeof(line)); // Reset color
                 strlcat(line, " ", sizeof(line));
             }
         }
@@ -122,7 +125,9 @@ void print_leaf_dnode(struct lyd_node *dnode, int pos, char **result) {
     char line[1024] = {0};
     strlcat(line, dnode->schema->name, sizeof(line));
     strlcat(line, " ", sizeof(line));
+    strlcat(line, BLUE, sizeof(line)); // Start color
     strlcat(line, lyd_get_value(dnode), sizeof(line));
+    strlcat(line, RESET, sizeof(line)); // Reset color
     strlcat(line, "\n", sizeof(line));
 
     size_t new_size = strlen(line) + 1; // Length of line + null terminator

--- a/src/commands/yang_core/y_utils.c
+++ b/src/commands/yang_core/y_utils.c
@@ -123,6 +123,19 @@ const char *get_relative_path(struct lysc_node *y_node) {
     return strdup(result);
 }
 
+struct lysc_node * get_parent_y_node_list(struct lysc_node *y_node){
+
+    struct lysc_node *y_nod_list_parent = y_node->parent;
+    while (y_nod_list_parent){
+        if (y_nod_list_parent->nodetype == LYS_LIST  )
+            break;
+        if (y_nod_list_parent->parent == NULL)
+            break;
+        y_nod_list_parent = y_nod_list_parent->parent;
+    }
+    return y_nod_list_parent;
+}
+
 struct cli_command *search_cmds(struct cli_command *commands, struct lysc_node **y_node) {
     struct cli_command *c;
     const char *root_module = lysc_owner_module(*y_node)->name;

--- a/src/commands/yang_core/y_utils.h
+++ b/src/commands/yang_core/y_utils.h
@@ -20,6 +20,8 @@ struct cli_ctx_data {
 
 int get_extension(char *ext_name, const struct lysc_node *snode, char **value);
 
+struct lysc_node *get_parent_y_node_list(struct lysc_node *y_node);
+
 char *get_root_ynode_cmd_name(struct lysc_node *y_node);
 
 char *create_list_predicate_from_optargs(struct cli_def *cli, struct lysc_node *y_node);

--- a/src/onm_logger.c
+++ b/src/onm_logger.c
@@ -25,6 +25,7 @@ void initLogger(const char *logFileName) {
     logFile = fopen(logFileName, "a");
     if (logFile == NULL) {
         perror("Error opening log file");
+        printf("\nMake sure to run \"sudo make install\" before running onmcli\n");
         exit(1);
     }
 }

--- a/src/onm_sysrepo.c
+++ b/src/onm_sysrepo.c
@@ -16,28 +16,11 @@
 #include "onm_logger.h"
 
 static sr_conn_ctx_t *connection = NULL;
-static sr_session_ctx_t *session = NULL, *startup_session = NULL, *operational_session = NULL;
+static sr_session_ctx_t *session = NULL, *running_session = NULL, *startup_session = NULL, *operational_session = NULL;
 
-struct data_tree *config_root_tree;
 
 char *module_path = NULL;
 
-void free_data_tree(struct data_tree *dtree) {
-    lyd_free_all(dtree->node);
-    dtree->prev = NULL;
-    free(dtree);
-}
-
-void free_data_tree_all() {
-    struct data_tree *curr_node = config_root_tree;
-    while (curr_node != NULL) {
-        struct data_tree *next_node = curr_node->prev;  // Save the pointer to the next node
-        lyd_free_all(curr_node->node);
-        free(curr_node);
-        curr_node = next_node;  // Move to the next node
-    }
-    config_root_tree = NULL;
-}
 
 // forward declaration
 int sysrepo_disconnect();
@@ -114,13 +97,19 @@ int sysrepo_disconnect() {
 }
 
 int sysrepo_start_session() {
-    // Start a new session
+    // Start a edit session
     if (sr_session_start(connection, SR_DS_RUNNING, &session) != SR_ERR_OK) {
+        LOG_ERROR("Failed to start a new Sysrepo session");
+        return EXIT_FAILURE;
+    }
+    // start running session
+    if (sr_session_start(connection, SR_DS_RUNNING, &running_session) != SR_ERR_OK) {
         LOG_ERROR("Failed to start a new Sysrepo session");
         return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;
 }
+
 
 int sysrepo_start_session_startup() {
     // Start a new session
@@ -149,6 +138,10 @@ const struct ly_ctx *sysrepo_get_ctx() {
 
 sr_session_ctx_t *sysrepo_get_session() {
     return session;
+}
+
+sr_session_ctx_t *sysrepo_get_running_session() {
+    return running_session;
 }
 
 sr_session_ctx_t *sysrepo_get_session_startup() {
@@ -184,49 +177,17 @@ int sysrepo_discard_changes() {
     return sr_discard_changes(session);
 }
 
-
-int sysrepo_has_uncommited_changes(struct lyd_node *data_node) {
-    // get the respective data_node from sysrepo, and compare it with current data_node.
-    // 0 no changes, 1 there is changes.
-    char xpath[256];
-    memset(xpath, '\0', 256);
-    lyd_path(data_node, LYD_PATH_STD, xpath, 256);
-    sr_data_t *sysrepo_subtree;
-    int ret = sr_get_subtree(sysrepo_get_session(), xpath, 0, &sysrepo_subtree);
-    if (ret == SR_ERR_OK && sysrepo_subtree) {
-        struct lyd_node *diff;
-        lyd_diff_tree(data_node, sysrepo_subtree->tree, 0, &diff);
-        sr_release_data(sysrepo_subtree);
-        if (diff != NULL)
-            return 1;
+int sysrepo_commit() {
+    // Apply the changes (if any)
+    if (sr_apply_changes(session, 0) != SR_ERR_OK) {
+        LOG_ERROR("Failed to commit changes to Sysrepo");
+        return EXIT_FAILURE;
     }
-    if (ret == SR_ERR_NOT_FOUND)
-        return 1;
-    return 0;
-}
 
-int sysrepo_commit(struct lyd_node *data_tree) {
-    // Check if there is data_tree to add and apply
-
-    if (data_tree != NULL) {
-        // If there are changes in the session, add the data_tree using sr_edit_batch
-        if (sr_edit_batch(session, data_tree, "replace") != SR_ERR_OK) {
-            LOG_ERROR("Failed to add data_tree to Sysrepo changes");
-            return EXIT_FAILURE;
-        }
-        // Apply the changes (if any)
-        if (sr_apply_changes(session, 0) != SR_ERR_OK) {
-            LOG_ERROR("Failed to commit changes to Sysrepo");
-            sr_discard_changes(session);
-            return EXIT_FAILURE;
-        }
-
-    }
     return EXIT_SUCCESS;
 }
 
 int onm_sysrepo_done() {
-    free_data_tree_all();
     sysrepo_disconnect();
     return EXIT_SUCCESS;
 }
@@ -255,7 +216,7 @@ int onm_sysrepo_init() {
 
     if (sysrepo_start_session_operational() != EXIT_SUCCESS)
         return EXIT_FAILURE;
-    sr_log_stderr(SR_LL_NONE);
+
     return EXIT_SUCCESS;
 
 }

--- a/src/onm_sysrepo.h
+++ b/src/onm_sysrepo.h
@@ -6,19 +6,11 @@
 #include <sysrepo.h>
 #include "lib/libcli/libcli.h"
 
-struct data_tree {
-    struct lyd_node *node;
-    struct data_tree *prev;
-};
-
-
 int sysrepo_release_ctx();
 
 int sysrepo_discard_changes();
 
-int sysrepo_has_uncommited_changes(struct lyd_node *data_node);
-
-int sysrepo_commit(struct lyd_node *data_tree);
+int sysrepo_commit();
 
 int onm_sysrepo_init();
 
@@ -36,14 +28,12 @@ const struct ly_ctx *sysrepo_get_ctx();
 
 sr_session_ctx_t *sysrepo_get_session();
 
+sr_session_ctx_t *sysrepo_get_running_session();
+
 sr_session_ctx_t *sysrepo_get_session_startup();
 
 sr_session_ctx_t *sysrepo_get_session_operational();
 
 void sysrepo_set_module_path(char *path);
-
-void free_data_tree(struct data_tree *dtree);
-
-void free_data_tree_all();
 
 #endif //ONMCLI_ONM_SYSREPO_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,6 +9,16 @@
 #include <string.h>
 #include "lib/libcli/libcli.h"
 
+// defnie colores.
+#define RESET "\033[0m"
+#define RED "\033[31m"
+#define GREEN "\033[32m"
+#define YELLOW "\033[33m"
+#define BLUE "\033[34m"
+#define MAGENTA "\033[35m"
+#define CYAN "\033[36m"
+#define WHITE "\033[37m"
+
 unsigned int str2int_hash(char *str, ...);
 
 void str2fun_name(char *str);


### PR DESCRIPTION

[major,core]: major change for how onm-cli build the config.

- use item_set and ietm_delete to the current sysrepo_session.
- supprot printing all config for all datastores.
- fix auto completions at none top level list.